### PR TITLE
configure.ac: modernize obsolete Autotools macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_INIT([ksmbd-tools],
         [https://github.com/cifsd-team/ksmbd-tools])
 
 AC_CONFIG_SRCDIR([config.h.in])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign tar-pax subdir-objects])
@@ -20,9 +20,9 @@ AC_SUBST([ksmbd_tools_version], ksmbd_tools_version)
 
 AC_LANG([C])
 AC_PROG_CC
-AC_PROG_CC_STDC
+AC_PROG_CC
 AM_SILENT_RULES([yes])
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_SED
 AC_PROG_MKDIR_P
 AC_PROG_LN_S
@@ -35,7 +35,7 @@ AC_SUBST([in_script], [[\
                        ]])
 
 AC_ARG_ENABLE([krb5],
-              [AC_HELP_STRING([--enable-krb5], [Enable Kerberos 5 authentication @<:@default=no@:>@])],
+              [AS_HELP_STRING([--enable-krb5], [Enable Kerberos 5 authentication @<:@default=no@:>@])],
               [enable_krb5=$enableval],
               [enable_krb5=no])
 
@@ -58,7 +58,7 @@ AS_IF([test "x$enable_krb5" != xno], [
 ])
 
 AC_ARG_WITH([rundir],
-            [AC_HELP_STRING([--with-rundir=DIR],
+            [AS_HELP_STRING([--with-rundir=DIR],
                             [Store modifiable per-process data in DIR @<:@LOCALSTATEDIR/run@:>@])],
             [with_rundir=$withval],
             [with_rundir=no])
@@ -74,7 +74,7 @@ AS_IF([test "x$with_rundir" = xno], [
 AC_SUBST([runstatedir])
 
 AC_ARG_WITH([systemdsystemunitdir],
-            [AC_HELP_STRING([--with-systemdsystemunitdir@<:@=DIR@:>@],
+            [AS_HELP_STRING([--with-systemdsystemunitdir@<:@=DIR@:>@],
                             [Install systemd unit file to DIR (query pkg-config by default)])],
             [with_systemdsystemunitdir=$withval],
             [with_systemdsystemunitdir=yes])

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -373,13 +373,13 @@ static void __handle_login_request(struct ksmbd_login_response *resp,
 {
 	int hash_sz;
 
+	g_rw_lock_reader_lock(&user->update_lock);
 	resp->gid = user->gid;
 	resp->uid = user->uid;
-	resp->status = user->flags;
-	resp->status |= KSMBD_USER_FLAG_OK;
-
+	resp->status = user->flags | KSMBD_USER_FLAG_OK;
 	if (user->ngroups)
 		resp->status |= KSMBD_USER_FLAG_EXTENSION;
+	g_rw_lock_reader_unlock(&user->update_lock);
 
 	hash_sz = usm_copy_user_passhash(user,
 					 resp->hash,

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -456,6 +456,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 	if (!user)
 		return -ENOENT;
 
+	g_rw_lock_writer_lock(&user->update_lock);
 	if (req->account_flags & KSMBD_USER_FLAG_BAD_PASSWORD) {
 		if (user->failed_login_count < 10)
 			user->failed_login_count++;
@@ -465,6 +466,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 		user->failed_login_count = 0;
 		user->flags &= ~KSMBD_USER_FLAG_DELAY_SESSION;
 	}
+	g_rw_lock_writer_unlock(&user->update_lock);
 
 	put_ksmbd_user(user);
 	return 0;

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -294,7 +294,9 @@ int usm_add_guest_account(char *name)
 	if (!user) {
 		ret = -EINVAL;
 	} else {
+		g_rw_lock_writer_lock(&user->update_lock);
 		set_user_flag(user, KSMBD_USER_FLAG_GUEST_ACCOUNT);
+		g_rw_lock_writer_unlock(&user->update_lock);
 		put_ksmbd_user(user);
 	}
 	return ret;


### PR DESCRIPTION
Running autogen.sh currently produces several deprecation warnings because the build system uses outdated Autoconf macros. These macros have been superseded by modern equivalents in recent Autotools releases.

Link: https://github.com/namjaejeon/ksmbd-tools/actions/runs/25304488315/job/74177493953#step:3:283

Replace the following obsolete macros:
- AC_CONFIG_HEADER -> AC_CONFIG_HEADERS
- AC_PROG_CC_STDC -> AC_PROG_CC (now handles standard detection automatically)
- AC_PROG_LIBTOOL -> LT_INIT
- AC_HELP_STRING -> AS_HELP_STRING

Tested-by:  Yunseong Kim <yunseong.kim@est.tech>
Link: https://github.com/kzall0c/ksmbd-tools/actions/runs/25316093142
Signed-off-by: Yunseong Kim <yunseong.kim@est.tech>