### PR TITLE
configure.ac: add sanitizer build support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -61,3 +61,21 @@ jobs:
         cd meson-heimdal-krb5-build
         meson -Dkrb5=enabled -Dkrb5_name=heimdal-krb5 ..
         meson dist
+    - name: clang build with asan
+      run: |
+        mkdir clang-asan-build
+        cd clang-asan-build
+        CC=clang ../configure --enable-asan
+        make
+    - name: clang build with msan
+      run: |
+        mkdir clang-msan-build
+        cd clang-msan-build
+        CC=clang ../configure --enable-msan
+        make
+    - name: clang build with tsan
+      run: |
+        mkdir clang-tsan-build
+        cd clang-tsan-build
+        CC=clang ../configure --enable-tsan
+        make

--- a/addshare/Makefile.am
+++ b/addshare/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS)
 
 noinst_LIBRARIES = libaddshare.a
 libaddshare_a_SOURCES = share_admin.c addshare.c share_admin.h

--- a/addshare/Makefile.am
+++ b/addshare/Makefile.am
@@ -1,5 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
-            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
+            $(ASAN_CFLAGS)
 
 noinst_LIBRARIES = libaddshare.a
 libaddshare_a_SOURCES = share_admin.c addshare.c share_admin.h

--- a/addshare/Makefile.am
+++ b/addshare/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
 
 noinst_LIBRARIES = libaddshare.a
 libaddshare_a_SOURCES = share_admin.c addshare.c share_admin.h

--- a/adduser/Makefile.am
+++ b/adduser/Makefile.am
@@ -1,5 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
-            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
+            $(ASAN_CFLAGS)
 
 noinst_LIBRARIES = libadduser.a
 libadduser_a_SOURCES = md4_hash.c user_admin.c adduser.c md4_hash.h user_admin.h

--- a/adduser/Makefile.am
+++ b/adduser/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
 
 noinst_LIBRARIES = libadduser.a
 libadduser_a_SOURCES = md4_hash.c user_admin.c adduser.c md4_hash.h user_admin.h

--- a/adduser/Makefile.am
+++ b/adduser/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS)
 
 noinst_LIBRARIES = libadduser.a
 libadduser_a_SOURCES = md4_hash.c user_admin.c adduser.c md4_hash.h user_admin.h

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,19 @@ AS_IF([test "x$enable_krb5" != xno], [
 	])
 ])
 
+AC_ARG_ENABLE([asan],
+              [AS_HELP_STRING([--enable-asan], [Enable AddressSanitizer @<:@default=no@:>@])],
+              [enable_asan=$enableval],
+              [enable_asan=no])
+
+AS_IF([test "x$enable_asan" != xno], [
+	ASAN_CFLAGS="-O0 -g -fsanitize=address,leak,undefined -fno-omit-frame-pointer"
+	ASAN_LDFLAGS="-fsanitize=address,leak,undefined"
+])
+
+AC_SUBST([ASAN_CFLAGS])
+AC_SUBST([ASAN_LDFLAGS])
+
 AC_ARG_WITH([rundir],
             [AC_HELP_STRING([--with-rundir=DIR],
                             [Store modifiable per-process data in DIR @<:@LOCALSTATEDIR/run@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,25 @@ AS_IF([test "x$enable_asan" != xno], [
 AC_SUBST([ASAN_CFLAGS])
 AC_SUBST([ASAN_LDFLAGS])
 
+AC_ARG_ENABLE([msan],
+              [AS_HELP_STRING([--enable-msan], [Enable MemorySanitizer (requires clang) @<:@default=no@:>@])],
+              [enable_msan=$enableval],
+              [enable_msan=no])
+
+AS_IF([test "x$enable_msan" != xno], [
+	AS_IF([! $CC -v 2>&1 | grep -q clang], [
+		AC_MSG_ERROR([MemorySanitizer requires clang. Use CC=clang ./configure --enable-msan])
+	])
+	AS_IF([test "x$enable_asan" != xno], [
+		AC_MSG_ERROR([--enable-asan and --enable-msan are mutually exclusive.])
+	])
+	MSAN_CFLAGS="-O0 -g -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer"
+	MSAN_LDFLAGS="-fsanitize=memory"
+])
+
+AC_SUBST([MSAN_CFLAGS])
+AC_SUBST([MSAN_LDFLAGS])
+
 AC_ARG_WITH([rundir],
             [AC_HELP_STRING([--with-rundir=DIR],
                             [Store modifiable per-process data in DIR @<:@LOCALSTATEDIR/run@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AS_IF([test "x$enable_msan" != xno], [
 		AC_MSG_ERROR([MemorySanitizer requires clang. Use CC=clang ./configure --enable-msan])
 	])
 	AS_IF([test "x$enable_asan" != xno], [
-		AC_MSG_ERROR([--enable-asan and --enable-msan are mutually exclusive.])
+		AC_MSG_ERROR([--enable-asan, --enable-msan, and --enable-tsan are mutually exclusive.])
 	])
 	MSAN_CFLAGS="-O0 -g -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer"
 	MSAN_LDFLAGS="-fsanitize=memory"
@@ -88,6 +88,22 @@ AS_IF([test "x$enable_msan" != xno], [
 
 AC_SUBST([MSAN_CFLAGS])
 AC_SUBST([MSAN_LDFLAGS])
+
+AC_ARG_ENABLE([tsan],
+              [AS_HELP_STRING([--enable-tsan], [Enable ThreadSanitizer @<:@default=no@:>@])],
+              [enable_tsan=$enableval],
+              [enable_tsan=no])
+
+AS_IF([test "x$enable_tsan" != xno], [
+	AS_IF([test "x$enable_asan" != xno || test "x$enable_msan" != xno], [
+		AC_MSG_ERROR([--enable-asan, --enable-msan, and --enable-tsan are mutually exclusive.])
+	])
+	TSAN_CFLAGS="-O0 -g -fsanitize=thread -fno-omit-frame-pointer"
+	TSAN_LDFLAGS="-fsanitize=thread"
+])
+
+AC_SUBST([TSAN_CFLAGS])
+AC_SUBST([TSAN_LDFLAGS])
 
 AC_ARG_WITH([rundir],
             [AC_HELP_STRING([--with-rundir=DIR],

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -1,5 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
-            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
+            $(ASAN_CFLAGS)
 
 noinst_LIBRARIES = libcontrol.a
 libcontrol_a_SOURCES = control.c

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
 
 noinst_LIBRARIES = libcontrol.a
 libcontrol_a_SOURCES = control.c

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS)
 
 noinst_LIBRARIES = libcontrol.a
 libcontrol_a_SOURCES = control.c

--- a/mountd/Makefile.am
+++ b/mountd/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS)
 
 noinst_LIBRARIES = libmountd.a
 libmountd_a_SOURCES = worker.c ipc.c rpc.c rpc_srvsvc.c rpc_wkssvc.c mountd.c \

--- a/mountd/Makefile.am
+++ b/mountd/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
 
 noinst_LIBRARIES = libmountd.a
 libmountd_a_SOURCES = worker.c ipc.c rpc.c rpc_srvsvc.c rpc_wkssvc.c mountd.c \

--- a/mountd/Makefile.am
+++ b/mountd/Makefile.am
@@ -1,5 +1,6 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
-            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common \
+            $(ASAN_CFLAGS)
 
 noinst_LIBRARIES = libmountd.a
 libmountd_a_SOURCES = worker.c ipc.c rpc.c rpc_srvsvc.c rpc_wkssvc.c mountd.c \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS)
-AM_LDFLAGS = $(ASAN_LDFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
+AM_LDFLAGS = $(ASAN_LDFLAGS) $(MSAN_LDFLAGS)
 LIBS = $(GLIB_LIBS) $(LIBNL_LIBS) $(LIBKRB5_LIBS) $(PTHREAD_LIBS)
 
 EXTRA_DIST = meson.build

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
             -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common \
-            $(ASAN_CFLAGS) $(MSAN_CFLAGS)
-AM_LDFLAGS = $(ASAN_LDFLAGS) $(MSAN_LDFLAGS)
+            $(ASAN_CFLAGS) $(MSAN_CFLAGS) $(TSAN_CFLAGS)
+AM_LDFLAGS = $(ASAN_LDFLAGS) $(MSAN_LDFLAGS) $(TSAN_LDFLAGS)
 LIBS = $(GLIB_LIBS) $(LIBNL_LIBS) $(LIBKRB5_LIBS) $(PTHREAD_LIBS)
 
 EXTRA_DIST = meson.build

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,7 @@
 AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -DRUNSTATEDIR='"${runstatedir}"' \
-            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common
+            -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common \
+            $(ASAN_CFLAGS)
+AM_LDFLAGS = $(ASAN_LDFLAGS)
 LIBS = $(GLIB_LIBS) $(LIBNL_LIBS) $(LIBKRB5_LIBS) $(PTHREAD_LIBS)
 
 EXTRA_DIST = meson.build

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -373,13 +373,13 @@ static void __handle_login_request(struct ksmbd_login_response *resp,
 {
 	int hash_sz;
 
+	g_rw_lock_reader_lock(&user->update_lock);
 	resp->gid = user->gid;
 	resp->uid = user->uid;
-	resp->status = user->flags;
-	resp->status |= KSMBD_USER_FLAG_OK;
-
+	resp->status = user->flags | KSMBD_USER_FLAG_OK;
 	if (user->ngroups)
 		resp->status |= KSMBD_USER_FLAG_EXTENSION;
+	g_rw_lock_reader_unlock(&user->update_lock);
 
 	hash_sz = usm_copy_user_passhash(user,
 					 resp->hash,

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -456,6 +456,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 	if (!user)
 		return -ENOENT;
 
+	g_rw_lock_writer_lock(&user->update_lock);
 	if (req->account_flags & KSMBD_USER_FLAG_BAD_PASSWORD) {
 		if (user->failed_login_count < 10)
 			user->failed_login_count++;
@@ -465,6 +466,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 		user->failed_login_count = 0;
 		user->flags &= ~KSMBD_USER_FLAG_DELAY_SESSION;
 	}
+	g_rw_lock_writer_unlock(&user->update_lock);
 
 	put_ksmbd_user(user);
 	return 0;

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -294,7 +294,9 @@ int usm_add_guest_account(char *name)
 	if (!user) {
 		ret = -EINVAL;
 	} else {
+		g_rw_lock_writer_lock(&user->update_lock);
 		set_user_flag(user, KSMBD_USER_FLAG_GUEST_ACCOUNT);
+		g_rw_lock_writer_unlock(&user->update_lock);
 		put_ksmbd_user(user);
 	}
 	return ret;


### PR DESCRIPTION
This series adds compile-time sanitizer support to ksmbd-tools via
Autotools configure flags, enabling runtime detection of common memory
and concurrency bugs during development and testing.

The following sanitizers are supported:

  `--enable-asan`  AddressSanitizer (address, leak, undefined)
  `--enable-msan`  MemorySanitizer (requires clang)
  `--enable-tsan`  ThreadSanitizer

These three sanitizers are mutually exclusive at build time, as they
cannot coexist in a single binary. MemorySanitizer additionally
requires clang, and configure will error out if CC is not clang.

The flags are wired into AM_CFLAGS/AM_LDFLAGS across all subdirectory
Makefile.am files. When none of the --enable-*san options are given,
the variables are empty and the build is unaffected.

A GitHub Actions CI step is also added to build-test all three
sanitizers with clang.

Yunseong Kim (4):
 - configure.ac: add --enable-asan
 -  configure.ac: add --enable-msan
 - configure.ac: add --enable-tsan
 - ksmbd: github action: add clang build with sanitizer
  
  Signed-off-by: Yunseong Kim <yunseong.kim@est.tech>